### PR TITLE
Rename branding to The Thrifty Pigeon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ThriftyPigeon v1 — Playbook Mint MVP
+# ThriftyPigeon v1 — The Thrifty Pigeon MVP
 
-This repository tracks the Playbook Mint MVP implementation. The primary web app lives in [`playbook-mint/`](playbook-mint/), a Next.js App Router project with Tailwind CSS and MDX-driven content. Refer to [`PRD.md`](PRD.md) for the full product requirements and to [`SCRATCHPAD.md`](SCRATCHPAD.md) for ongoing implementation notes.
+This repository tracks The Thrifty Pigeon MVP implementation. The primary web app lives in [`playbook-mint/`](playbook-mint/), a Next.js App Router project with Tailwind CSS and MDX-driven content. Refer to [`PRD.md`](PRD.md) for the full product requirements and to [`SCRATCHPAD.md`](SCRATCHPAD.md) for ongoing implementation notes.
 
 ## Quick start
 

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,4 +1,4 @@
-# Playbook Mint Implementation Notes
+# The Thrifty Pigeon Implementation Notes
 
 ## TODO
 - [x] Review PRD requirements and define MVP scope for initial commit.

--- a/playbook-mint/README.md
+++ b/playbook-mint/README.md
@@ -1,6 +1,6 @@
-# Playbook Mint
+# The Thrifty Pigeon
 
-Playbook Mint is a content-first micro-playbook platform that turns organic traffic into $5–$9 impulse purchases. The app is built with the Next.js App Router, Tailwind CSS, and MDX-based content to mirror the funnel defined in the PRD.
+The Thrifty Pigeon is a content-first micro-playbook platform that turns organic traffic into $5–$9 impulse purchases. The app is built with the Next.js App Router, Tailwind CSS, and MDX-based content to mirror the funnel defined in the PRD.
 
 ## Project structure
 

--- a/playbook-mint/src/app/(site)/about/page.tsx
+++ b/playbook-mint/src/app/(site)/about/page.tsx
@@ -1,6 +1,6 @@
 export const metadata = {
-  title: "About | Playbook Mint",
-  description: "The story behind Playbook Mint and the micro-playbook model.",
+  title: "About | The Thrifty Pigeon",
+  description: "The story behind The Thrifty Pigeon and the micro-playbook model.",
 };
 
 export default function AboutPage() {
@@ -10,7 +10,7 @@ export default function AboutPage() {
       <h1 className="mt-4 font-heading text-4xl font-semibold text-ink-900">Building a machine that turns helpful content into happy customers</h1>
       <div className="prose prose-lg mt-6 max-w-none text-ink-700">
         <p>
-          Playbook Mint exists for motivated searchers who want answers now. We publish free, SEO-driven guides that solve real problems and offer $5-$9 extended playbooks for readers ready to execute the full system.
+          The Thrifty Pigeon exists for motivated searchers who want answers now. We publish free, SEO-driven guides that solve real problems and offer $5-$9 extended playbooks for readers ready to execute the full system.
         </p>
         <p>
           Our team has shipped dozens of digital products, run growth at fintech startups, and consulted on high-performing funnels. The result: a repeatable playbook for attracting intent-driven traffic and converting it into instant downloads.

--- a/playbook-mint/src/app/(site)/articles/[slug]/page.tsx
+++ b/playbook-mint/src/app/(site)/articles/[slug]/page.tsx
@@ -23,14 +23,14 @@ export async function generateMetadata({
 
   if (!article) {
     return {
-      title: "Article not found | Playbook Mint",
+      title: "Article not found | The Thrifty Pigeon",
     };
   }
 
   const published = article.publishedAt.toISOString();
 
   return {
-    title: `${article.title} | Playbook Mint`,
+    title: `${article.title} | The Thrifty Pigeon`,
     description: article.description,
     openGraph: {
       title: article.title,
@@ -69,7 +69,7 @@ export default async function ArticlePage({
         </Link>
         <header className="mt-6 space-y-6">
           <p className="text-sm font-semibold uppercase tracking-wide text-brand-600">
-            {article.tags.join(" · ") || "Playbook Mint"}
+            {article.tags.join(" · ") || "The Thrifty Pigeon"}
           </p>
           <h1 className="font-heading text-4xl font-semibold text-ink-900 sm:text-5xl">
             {article.title}

--- a/playbook-mint/src/app/(site)/articles/page.tsx
+++ b/playbook-mint/src/app/(site)/articles/page.tsx
@@ -3,9 +3,9 @@ import { listArticles } from "@/lib/articles";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Articles | Playbook Mint",
+  title: "Articles | The Thrifty Pigeon",
   description:
-    "Free how-to guides and listicles that lead into our $5-$9 extended playbooks. Browse the latest content from Playbook Mint.",
+    "Free how-to guides and listicles that lead into our $5-$9 extended playbooks. Browse the latest content from The Thrifty Pigeon.",
 };
 
 export default async function ArticlesIndexPage() {

--- a/playbook-mint/src/app/(site)/contact/page.tsx
+++ b/playbook-mint/src/app/(site)/contact/page.tsx
@@ -1,6 +1,6 @@
 export const metadata = {
-  title: "Contact | Playbook Mint",
-  description: "Get in touch with the Playbook Mint team for partnerships, support, or press inquiries.",
+  title: "Contact | The Thrifty Pigeon",
+  description: "Get in touch with The Thrifty Pigeon team for partnerships, support, or press inquiries.",
 };
 
 export default function ContactPage() {
@@ -53,7 +53,7 @@ export default function ContactPage() {
             Send message
           </button>
         </form>
-        <p className="mt-4 text-xs text-ink-500">Prefer email? Reach us directly at hello@playbookmint.com.</p>
+        <p className="mt-4 text-xs text-ink-500">Prefer email? Reach us directly at hello@thethriftypigeon.com.</p>
       </div>
     </div>
   );

--- a/playbook-mint/src/app/(site)/newsletter/page.tsx
+++ b/playbook-mint/src/app/(site)/newsletter/page.tsx
@@ -1,7 +1,7 @@
 export const metadata = {
-  title: "Newsletter | Playbook Mint",
+  title: "Newsletter | The Thrifty Pigeon",
   description:
-    "Join the Playbook Mint newsletter for field-tested tactics, best-performing articles, and subscriber-only playbook discounts.",
+    "Join The Thrifty Pigeon newsletter for field-tested tactics, best-performing articles, and subscriber-only playbook discounts.",
 };
 
 export default function NewsletterPage() {
@@ -10,7 +10,7 @@ export default function NewsletterPage() {
       <p className="text-sm font-semibold uppercase tracking-wide text-brand-600">Newsletter</p>
       <h1 className="mt-4 font-heading text-4xl font-semibold text-ink-900">Weekly funnel breakdowns + bonus playbook drops</h1>
       <p className="mt-4 text-lg text-ink-700">
-        Subscribe to get deep dives on the content → CTA → checkout flow that powers Playbook Mint. Every issue includes a teardown, an optimization checklist, and early-bird pricing on new playbooks.
+        Subscribe to get deep dives on the content → CTA → checkout flow that powers The Thrifty Pigeon. Every issue includes a teardown, an optimization checklist, and early-bird pricing on new playbooks.
       </p>
       <div className="mt-10 rounded-3xl border border-brand-100 bg-brand-50/60 p-8 shadow-soft">
         <form className="flex flex-col gap-4 sm:flex-row">

--- a/playbook-mint/src/app/(site)/page.tsx
+++ b/playbook-mint/src/app/(site)/page.tsx
@@ -12,7 +12,7 @@ export default async function HomePage() {
         <div className="grid gap-10 md:grid-cols-[1.2fr_1fr] md:items-center">
           <div className="space-y-6">
             <span className="inline-flex items-center rounded-full border border-brand-100 bg-brand-50/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-brand-600">
-              Playbook Mint
+              The Thrifty Pigeon
             </span>
             <h1 className="font-heading text-4xl font-semibold tracking-tight text-ink-900 sm:text-5xl">
               Free guides that unlock $5 playbooks your future self will thank you for.

--- a/playbook-mint/src/app/(site)/playbooks/page.tsx
+++ b/playbook-mint/src/app/(site)/playbooks/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { listPlaybooks } from "@/data/playbooks";
 
 export const metadata = {
-  title: "Playbooks | Playbook Mint",
+  title: "Playbooks | The Thrifty Pigeon",
   description:
     "Instant-download playbooks designed to turn motivated readers into paying customers. Each comes with scripts, templates, and automation recipes.",
 };

--- a/playbook-mint/src/app/(site)/press/page.tsx
+++ b/playbook-mint/src/app/(site)/press/page.tsx
@@ -1,6 +1,6 @@
 export const metadata = {
-  title: "Press Kit | Playbook Mint",
-  description: "Press-ready assets, company facts, and contact info for Playbook Mint.",
+  title: "Press Kit | The Thrifty Pigeon",
+  description: "Press-ready assets, company facts, and contact info for The Thrifty Pigeon.",
 };
 
 export default function PressPage() {
@@ -10,7 +10,7 @@ export default function PressPage() {
       <h1 className="mt-4 font-heading text-4xl font-semibold text-ink-900">Press kit & fast facts</h1>
       <div className="prose prose-lg mt-6 max-w-none text-ink-700">
         <p>
-          Playbook Mint is a content-first micro-product brand helping motivated readers unlock instant-download playbooks. For interviews, quotes, or media assets, you can reach us at press@playbookmint.com.
+          The Thrifty Pigeon is a content-first micro-product brand helping motivated readers unlock instant-download playbooks. For interviews, quotes, or media assets, you can reach us at press@thethriftypigeon.com.
         </p>
         <ul>
           <li>Founded: 2024</li>

--- a/playbook-mint/src/app/icon.svg
+++ b/playbook-mint/src/app/icon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
-  <title id="title">Playbook Mint icon</title>
+  <title id="title">The Thrifty Pigeon icon</title>
   <desc id="desc">A minimalist mint leaf inside a rounded square</desc>
   <rect width="64" height="64" rx="12" fill="#0f172a" />
   <path d="M20 24c6-6 18-6 24 0s6 18 0 24-18 6-24 0-6-18 0-24z" fill="#34d399" />

--- a/playbook-mint/src/app/layout.tsx
+++ b/playbook-mint/src/app/layout.tsx
@@ -3,13 +3,13 @@ import type { ReactNode } from "react";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://playbookmint.com"),
+  metadataBase: new URL("https://thethriftypigeon.com"),
   title: {
-    default: "Playbook Mint — Micro playbooks that convert readers into buyers",
-    template: "%s | Playbook Mint",
+    default: "The Thrifty Pigeon — Micro playbooks that convert readers into buyers",
+    template: "%s | The Thrifty Pigeon",
   },
   description:
-    "Playbook Mint turns high-intent search traffic into instant $5-$9 playbook downloads with contextual CTAs and seamless checkout.",
+    "The Thrifty Pigeon turns high-intent search traffic into instant $5-$9 playbook downloads with contextual CTAs and seamless checkout.",
 };
 
 export default function RootLayout({

--- a/playbook-mint/src/components/layout/site-footer.tsx
+++ b/playbook-mint/src/components/layout/site-footer.tsx
@@ -27,9 +27,9 @@ export function SiteFooter() {
           <div className="space-y-4">
             <p className="inline-flex items-center gap-2 text-lg font-semibold">
               <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-brand-500 text-sm font-bold uppercase text-white shadow-sm">
-                PM
+                TP
               </span>
-              <span className="font-heading text-xl text-white">Playbook Mint</span>
+              <span className="font-heading text-xl text-white">The Thrifty Pigeon</span>
             </p>
             <p className="max-w-sm text-sm text-ink-200">
               Actionable playbooks for people who want to make smarter money moves without spending hours researching.
@@ -55,7 +55,7 @@ export function SiteFooter() {
           </div>
         </div>
         <div className="mt-12 border-t border-white/10 pt-6 text-xs text-ink-300">
-          © {new Date().getFullYear()} Playbook Mint. All rights reserved.
+          © {new Date().getFullYear()} The Thrifty Pigeon. All rights reserved.
         </div>
       </div>
     </footer>

--- a/playbook-mint/src/components/layout/site-header.tsx
+++ b/playbook-mint/src/components/layout/site-header.tsx
@@ -12,9 +12,9 @@ export function SiteHeader() {
       <div className="mx-auto flex h-16 max-w-content items-center justify-between px-4 sm:px-6 lg:px-8">
         <Link href="/" className="flex items-center gap-2 text-lg font-semibold text-ink-900">
           <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-brand-600 text-sm font-bold uppercase text-white shadow-sm">
-            PM
+            TP
           </span>
-          <span className="font-heading text-lg">Playbook Mint</span>
+          <span className="font-heading text-lg">The Thrifty Pigeon</span>
         </Link>
         <nav className="hidden items-center gap-6 text-sm font-medium text-ink-600 sm:flex">
           {navigation.map((item) => (


### PR DESCRIPTION
## Summary
- update repository and app copy to reference The Thrifty Pigeon instead of Playbook Mint
- refresh header/footer branding details, metadata defaults, and contact addresses for the new name
- adjust site metadata base URL to thethriftypigeon.com to match the rebrand

## Testing
- npm run lint *(fails: missing @eslint/eslintrc dependency in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f34905ec8330949043b0bb9f3f00