### PR TITLE
Handle missing Sanity stega studio URL

### DIFF
--- a/playbook-mint/src/lib/sanity/client.ts
+++ b/playbook-mint/src/lib/sanity/client.ts
@@ -1,21 +1,34 @@
 import { createClient } from "next-sanity";
 import { sanityConfig } from "./config";
 
+const stegaStudioUrl =
+  process.env.NEXT_PUBLIC_SANITY_STUDIO_URL || process.env.SANITY_STUDIO_URL;
+
+const readClientStegaConfig = stegaStudioUrl
+  ? {
+      enabled: process.env.NODE_ENV !== "production",
+      studioUrl: stegaStudioUrl,
+    }
+  : { enabled: false };
+
 export const readClient = createClient({
   ...sanityConfig,
   useCdn: sanityConfig.useCdn,
-  stega: {
-    enabled: process.env.NODE_ENV !== "production",
-  },
+  stega: readClientStegaConfig,
 });
 
 export function getPreviewClient(token?: string) {
+  const previewStegaConfig = stegaStudioUrl
+    ? {
+        enabled: true,
+        studioUrl: stegaStudioUrl,
+      }
+    : { enabled: false };
+
   return createClient({
     ...sanityConfig,
     token: token || process.env.SANITY_READ_TOKEN,
     useCdn: false,
-    stega: {
-      enabled: true,
-    },
+    stega: previewStegaConfig,
   });
 }


### PR DESCRIPTION
## Summary
- add a shared stega configuration that only enables Sanity stega mode when a studio URL is provided
- ensure both the read client and preview client supply the studio URL to avoid runtime errors in development

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9b9e223c8330bbde6daf25f736f5