### PR TITLE
feat: add sanity webhook revalidation

### DIFF
--- a/playbook-mint/README.md
+++ b/playbook-mint/README.md
@@ -66,7 +66,21 @@ SANITY_PROJECT_ID=your-project-id
 SANITY_DATASET=production
 SANITY_API_VERSION=2025-01-01
 SANITY_READ_TOKEN= # optional, only needed for preview/draft mode
+SANITY_REVALIDATE_SECRET= # required for ISR webhook verification
+SANITY_STUDIO_URL= # optional, used for Portable Text stega URLs
+NEXT_PUBLIC_SANITY_STUDIO_URL= # optional, expose Studio URL to the browser when needed
 ```
+
+### Automatic cache revalidation
+
+Configure a Sanity webhook to automatically refresh the article listing and detail pages whenever content changes:
+
+1. In the Sanity project settings, create a webhook pointing to your deployment's `/api/revalidate` endpoint (e.g. `https://thriftypigeon.com/api/revalidate`).
+2. Choose the **Article** dataset filter (or `*[_type == "article"]` GROQ filter) and enable draft events if you want draft previews to purge caches.
+3. Set the **HTTP method** to `POST`, set the **secret** to the same value as `SANITY_REVALIDATE_SECRET`, and enable the signature header.
+4. Deploy the updated environment variable alongside your Next.js app.
+
+On each publish, update, or delete event the webhook will invalidate the relevant cache tags and revalidate the affected article routes so readers always see the latest content.
 
 ## Next steps
 

--- a/playbook-mint/package-lock.json
+++ b/playbook-mint/package-lock.json
@@ -15,6 +15,7 @@
         "@react-email/render": "^1.3.1",
         "@sanity/client": "^6.24.2",
         "@sanity/image-url": "^1.1.0",
+        "@sanity/webhook": "^4.0.4",
         "clsx": "^2.1.1",
         "drizzle-kit": "^0.31.5",
         "drizzle-orm": "^0.44.5",
@@ -6774,6 +6775,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@sanity/webhook": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@sanity/webhook/-/webhook-4.0.4.tgz",
+      "integrity": "sha512-c8LmzR5Wx93zJ10ohhp0XlmPrTNSFyvPcLbNY/sN45Wj5VOngz4FbBMbX9j64sSQLt+676U6OhiVfjs1yw3YCw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@selderee/plugin-htmlparser2": {

--- a/playbook-mint/package.json
+++ b/playbook-mint/package.json
@@ -20,6 +20,7 @@
     "@portabletext/types": "^2.0.13",
     "@react-email/render": "^1.3.1",
     "@sanity/client": "^6.24.2",
+    "@sanity/webhook": "^4.0.4",
     "@sanity/image-url": "^1.1.0",
     "clsx": "^2.1.1",
     "drizzle-kit": "^0.31.5",

--- a/playbook-mint/src/app/api/revalidate/route.ts
+++ b/playbook-mint/src/app/api/revalidate/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest } from "next/server";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { isValidSignature, SIGNATURE_HEADER_NAME } from "@sanity/webhook";
+
+type SanitySlug = {
+  current?: string | null;
+};
+
+interface SanityWebhookPayload {
+  _type?: string;
+  slug?: SanitySlug;
+  draft?: { slug?: SanitySlug } | null;
+  previous?: { slug?: SanitySlug } | null;
+  transition?: "create" | "update" | "delete";
+}
+
+const ARTICLE_TYPE = "article";
+
+function extractSlug(payload: SanityWebhookPayload): string | null {
+  const slugCandidate =
+    payload.slug?.current ||
+    payload.draft?.slug?.current ||
+    payload.previous?.slug?.current ||
+    null;
+
+  return typeof slugCandidate === "string" && slugCandidate.length > 0
+    ? slugCandidate
+    : null;
+}
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  const secret = process.env.SANITY_REVALIDATE_SECRET;
+
+  if (!secret) {
+    return Response.json(
+      {
+        error: "Missing SANITY_REVALIDATE_SECRET environment variable",
+      },
+      { status: 500 },
+    );
+  }
+
+  const signature = request.headers.get(SIGNATURE_HEADER_NAME) ?? "";
+  const body = await request.text();
+
+  if (!isValidSignature(body, signature, secret)) {
+    return Response.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  let payload: SanityWebhookPayload;
+
+  try {
+    payload = JSON.parse(body) as SanityWebhookPayload;
+  } catch (error) {
+    return Response.json(
+      { error: "Unable to parse webhook payload", details: String(error) },
+      { status: 400 },
+    );
+  }
+
+  if (payload._type !== ARTICLE_TYPE) {
+    return Response.json({ skipped: true, reason: "Unsupported document type" });
+  }
+
+  const slug = extractSlug(payload);
+
+  revalidateTag("article-detail");
+  revalidateTag("article-list");
+  revalidateTag("article-slugs");
+
+  const revalidatedPaths: string[] = [];
+
+  if (slug) {
+    const articlePath = `/articles/${slug}`;
+    revalidatePath(articlePath);
+    revalidatedPaths.push(articlePath);
+  }
+
+  revalidatePath("/articles");
+  revalidatedPaths.push("/articles");
+
+  return Response.json({
+    revalidated: true,
+    slug,
+    transition: payload.transition,
+    paths: revalidatedPaths,
+  });
+}

--- a/playbook-mint/src/lib/articles.ts
+++ b/playbook-mint/src/lib/articles.ts
@@ -1,4 +1,4 @@
-import { cache } from "react";
+import { unstable_cache } from "next/cache";
 import readingTime from "reading-time";
 import { z } from "zod";
 import type { PortableTextBlock } from "@portabletext/types";
@@ -80,7 +80,7 @@ function mapArticle(record: ArticleRecord): ArticleFrontmatter {
   } satisfies ArticleFrontmatter;
 }
 
-export const getArticleBySlug = cache(async (slug: string): Promise<ArticleDetail> => {
+const fetchArticleDetail = async (slug: string): Promise<ArticleDetail> => {
   const result = await readClient.fetch(ARTICLE_QUERY, { slug });
   const parsed = articleDetailSchema.parse(result);
   const frontmatter = mapArticle(parsed);
@@ -89,23 +89,55 @@ export const getArticleBySlug = cache(async (slug: string): Promise<ArticleDetai
     ...frontmatter,
     body: parsed.body,
   } satisfies ArticleDetail;
-});
+};
 
-export const getArticleFrontmatter = cache(async (slug: string): Promise<ArticleFrontmatter> => {
-  const result = await readClient.fetch(ARTICLE_QUERY, { slug });
-  const parsed = articleDetailSchema.parse(result);
-  return mapArticle(parsed);
-});
-
-export const listArticles = cache(async (): Promise<ArticleFrontmatter[]> => {
+const fetchArticleList = async (): Promise<ArticleFrontmatter[]> => {
   const result = await readClient.fetch(ARTICLE_LIST_QUERY);
   const parsed = z.array(baseArticleSchema).parse(result ?? []);
   const articles = parsed.map(mapArticle);
   return articles.sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
-});
+};
 
-export const listArticleSlugs = cache(async (): Promise<string[]> => {
+const fetchArticleSlugs = async (): Promise<string[]> => {
   const result = await readClient.fetch(ARTICLE_SLUGS_QUERY);
   const parsed = z.array(z.string()).parse(result ?? []);
   return parsed;
+};
+
+export const getArticleBySlug = unstable_cache(fetchArticleDetail, [
+  "articles",
+  "detail",
+], {
+  tags: ["article-detail"],
+});
+
+export async function getArticleFrontmatter(slug: string): Promise<ArticleFrontmatter> {
+  const article = await getArticleBySlug(slug);
+
+  return {
+    title: article.title,
+    description: article.description,
+    slug: article.slug,
+    publishedAt: article.publishedAt,
+    updatedAt: article.updatedAt,
+    tags: article.tags,
+    heroImage: article.heroImage,
+    heroImageAlt: article.heroImageAlt ?? null,
+    playbookSku: article.playbookSku,
+    readingMinutes: article.readingMinutes,
+  } satisfies ArticleFrontmatter;
+}
+
+export const listArticles = unstable_cache(fetchArticleList, [
+  "articles",
+  "list",
+], {
+  tags: ["article-list"],
+});
+
+export const listArticleSlugs = unstable_cache(fetchArticleSlugs, [
+  "articles",
+  "slugs",
+], {
+  tags: ["article-slugs"],
 });

--- a/sanity-implementation-review.md
+++ b/sanity-implementation-review.md
@@ -1,0 +1,40 @@
+# Sanity Integration Review
+
+## Current Implementation Snapshot
+
+### Studio configuration (`playbook-mint/sanity`)
+- Sanity Studio lives in `playbook-mint/sanity` with a single project configuration that targets the `qdgro20q` project and `production` dataset, and loads the default desk structure plus Vision for GROQ debugging.【F:playbook-mint/sanity/sanity.config.ts†L1-L18】
+- The article document schema models all front matter fields we previously relied on in MDX: title, slug, SEO-friendly description, publish/update timestamps, tag arrays (capped at six), hero image with required alt text, optional listing alt override, a featured playbook SKU, and a rich `body` array that accepts block content, inline link annotations, images, code blocks, and a custom CTA object.【F:playbook-mint/sanity/schemaTypes/documents/article.ts†L3-L131】
+- A dedicated `ctaPlaybook` object type backs the article body CTA block so authors can embed SKU-specific upsells without manual JSX edits.【F:playbook-mint/sanity/schemaTypes/objects/ctaPlaybook.ts†L3-L24】
+
+### Application-side integration (`playbook-mint/src`)
+- Runtime configuration pulls `SANITY_PROJECT_ID`, `SANITY_DATASET`, and `SANITY_API_VERSION` from environment variables at module load; missing IDs throw eagerly to prevent silent misconfiguration.【F:playbook-mint/src/lib/sanity/config.ts†L1-L18】
+- `createClient` from `next-sanity` instantiates a CDN-enabled read client (with optional steganography overlays in non-production environments) and exposes a token-aware preview client, although no preview entry points consume it yet.【F:playbook-mint/src/lib/sanity/client.ts†L1-L34】
+- Centralized GROQ queries provide article detail, listing, and slug lookups—including derived plain-text bodies for reading-time calculations—giving the Next.js app a single source of truth for Sanity reads.【F:playbook-mint/src/lib/sanity/queries.ts†L1-L36】
+- `src/lib/articles.ts` wraps the Sanity client with Zod validation, runtime type coercion for Portable Text and images, and helpers for fetching individual articles, front matter summaries, collections, and static params; it also computes reading length from Portable Text output to preserve the existing UX badge.【F:playbook-mint/src/lib/articles.ts†L1-L111】
+- Portable Text rendering mirrors our MDX typography by mapping blocks, marks, lists, CTA objects, and responsive Sanity images to the design system, ensuring Sanity-authored content slots into existing layouts.【F:playbook-mint/src/components/sanity/portable-text.tsx†L1-L104】
+- Article routes (`/articles` and `/articles/[slug]`) already depend entirely on the Sanity-backed helpers for listing and rendering content, providing sensible empty states when the dataset has no published entries.【F:playbook-mint/src/app/(site)/articles/page.tsx†L1-L35】【F:playbook-mint/src/app/(site)/articles/[slug]/page.tsx†L1-L91】
+
+### Legacy surface area still in place
+- The MDX content directory (`playbook-mint/content/articles`) remains checked in, signalling that the migration is mid-flight and dual maintenance is still required until content is imported into Sanity.【F:playbook-mint/content/articles/beginner-budgeting-guide.mdx†L1-L40】
+
+## Strengths observed
+- **Parity-focused schema** – The article document captures all metadata we needed from MDX, with validation rules that enforce quality standards such as SEO-length descriptions and mandatory image alt text.【F:playbook-mint/sanity/schemaTypes/documents/article.ts†L7-L114】
+- **Type-safe data access** – Zod schemas guard our Sanity responses, reducing the risk of runtime regressions as editors start creating content.【F:playbook-mint/src/lib/articles.ts†L9-L111】
+- **Design-consistent rendering** – Custom Portable Text components replicate our MDX presentation layer, including CTA blocks, so we do not lose marketing hooks when switching backends.【F:playbook-mint/src/components/sanity/portable-text.tsx†L13-L104】
+
+## Gaps & technical risks
+- **Preview and drafts unimplemented** – Although a preview client helper exists, there is no draft-mode API route or middleware to surface unpublished changes, limiting editorial feedback loops.【F:playbook-mint/src/lib/sanity/client.ts†L20-L34】
+- **Revalidation strategy TBD** – Static routes call `cache` wrappers but do not declare `revalidate` intervals nor webhooks, so fresh publishes will not automatically appear in production without manual cache busting.【F:playbook-mint/src/lib/articles.ts†L83-L111】
+- **Environment management split** – The Studio hard-codes the project ID/dataset while the Next.js app expects env vars. Without documentation, it is easy for developers to configure one side and forget the other, or accidentally point Studio previews at the wrong dataset.【F:playbook-mint/sanity/sanity.config.ts†L6-L18】【F:playbook-mint/src/lib/sanity/config.ts†L1-L18】
+- **Content migration incomplete** – Legacy MDX files are still the source of truth; until they are imported (or an automated bridge exists) the Sanity-backed frontend will surface empty states in lower environments.【F:playbook-mint/content/articles/beginner-budgeting-guide.mdx†L1-L40】【F:playbook-mint/src/app/(site)/articles/page.tsx†L23-L31】
+- **Hero media unused on frontend** – Article listings/pages do not yet render the new `heroImage` field, reducing parity with the MDX experience and making it harder to validate image handling end-to-end.【F:playbook-mint/src/lib/articles.ts†L69-L80】【F:playbook-mint/src/app/(site)/articles/[slug]/page.tsx†L62-L88】
+- **Playbook SKU freeform** – The CTA object enforces a SKU string but does not validate against existing playbooks or provide authoring affordances (references, dropdowns), inviting typos until additional schema is added.【F:playbook-mint/sanity/schemaTypes/objects/ctaPlaybook.ts†L7-L24】
+
+## Recommended next steps
+1. **Finish content migration** – Import existing MDX articles into Sanity (or build a bridge script) so the live site is populated during rollout; remove the filesystem content once parity is verified.【F:playbook-mint/content/articles/beginner-budgeting-guide.mdx†L1-L40】【F:playbook-mint/src/lib/articles.ts†L83-L111】
+2. **Wire up preview & drafts** – Add a preview secret route, enable `draftMode`, and plumb the `getPreviewClient` into article pages so editors can QA unpublished changes safely.【F:playbook-mint/src/lib/sanity/client.ts†L20-L34】【F:playbook-mint/src/app/(site)/articles/[slug]/page.tsx†L51-L91】
+3. **Define revalidation + webhooks** – Decide on ISR timing or on-demand revalidation and configure Sanity webhooks to trigger Next.js cache busting after publishes.【F:playbook-mint/src/lib/articles.ts†L83-L111】
+4. **Document environment setup** – Create a shared doc (and `.env.example` entries) that lists required Sanity variables for both Studio and Next.js, and consider aligning Studio config to read from env to avoid drift.【F:playbook-mint/sanity/sanity.config.ts†L6-L18】【F:playbook-mint/src/lib/sanity/config.ts†L1-L18】
+5. **Surface hero media and CTAs** – Update article and listing templates to render `heroImage` blocks and validate CTA SKU inputs (e.g., via references to a playbook document) to complete parity with the MDX presentation.【F:playbook-mint/src/lib/articles.ts†L69-L80】【F:playbook-mint/src/components/sanity/portable-text.tsx†L63-L104】
+6. **Plan cleanup and dependency removal** – Once content lives in Sanity, remove unused MDX tooling/dependencies to reduce bundle size and maintenance overhead (e.g., delete `playbook-mint/content`, drop MDX packages).【F:playbook-mint/content/articles/beginner-budgeting-guide.mdx†L1-L40】【F:playbook-mint/src/lib/articles.ts†L1-L111】


### PR DESCRIPTION
## Summary
- add an authenticated Sanity webhook endpoint that revalidates article cache tags and routes after CMS updates
- switch Sanity article queries to Next.js `unstable_cache` wrappers with cache tags to support on-demand invalidation
- document the required environment variables and webhook setup for automatic cache refreshes

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6ed4661c833091d4f0de31b011f5