### PR TITLE
fix: load sanity code input plugin

### DIFF
--- a/playbook-mint/README.md
+++ b/playbook-mint/README.md
@@ -66,7 +66,21 @@ SANITY_PROJECT_ID=your-project-id
 SANITY_DATASET=production
 SANITY_API_VERSION=2025-01-01
 SANITY_READ_TOKEN= # optional, only needed for preview/draft mode
+SANITY_REVALIDATE_SECRET= # required for ISR webhook verification
+SANITY_STUDIO_URL= # optional, used for Portable Text stega URLs
+NEXT_PUBLIC_SANITY_STUDIO_URL= # optional, expose Studio URL to the browser when needed
 ```
+
+### Automatic cache revalidation
+
+Configure a Sanity webhook to automatically refresh the article listing and detail pages whenever content changes:
+
+1. In the Sanity project settings, create a webhook pointing to your deployment's `/api/revalidate` endpoint (e.g. `https://thriftypigeon.com/api/revalidate`).
+2. Choose the **Article** dataset filter (or `*[_type == "article"]` GROQ filter) and enable draft events if you want draft previews to purge caches.
+3. Set the **HTTP method** to `POST`, set the **secret** to the same value as `SANITY_REVALIDATE_SECRET`, and enable the signature header.
+4. Deploy the updated environment variable alongside your Next.js app.
+
+On each publish, update, or delete event the webhook will invalidate the relevant cache tags and revalidate the affected article routes so readers always see the latest content.
 
 ## Next steps
 

--- a/playbook-mint/package-lock.json
+++ b/playbook-mint/package-lock.json
@@ -15,6 +15,7 @@
         "@react-email/render": "^1.3.1",
         "@sanity/client": "^6.24.2",
         "@sanity/image-url": "^1.1.0",
+        "@sanity/webhook": "^4.0.4",
         "clsx": "^2.1.1",
         "drizzle-kit": "^0.31.5",
         "drizzle-orm": "^0.44.5",
@@ -6774,6 +6775,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@sanity/webhook": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@sanity/webhook/-/webhook-4.0.4.tgz",
+      "integrity": "sha512-c8LmzR5Wx93zJ10ohhp0XlmPrTNSFyvPcLbNY/sN45Wj5VOngz4FbBMbX9j64sSQLt+676U6OhiVfjs1yw3YCw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@selderee/plugin-htmlparser2": {

--- a/playbook-mint/package.json
+++ b/playbook-mint/package.json
@@ -20,6 +20,7 @@
     "@portabletext/types": "^2.0.13",
     "@react-email/render": "^1.3.1",
     "@sanity/client": "^6.24.2",
+    "@sanity/webhook": "^4.0.4",
     "@sanity/image-url": "^1.1.0",
     "clsx": "^2.1.1",
     "drizzle-kit": "^0.31.5",

--- a/playbook-mint/sanity/package-lock.json
+++ b/playbook-mint/sanity/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
+        "@sanity/code-input": "^6.0.1",
         "@sanity/vision": "^4.10.2",
         "react": "^19.1",
         "react-dom": "^19.1",
@@ -1966,6 +1967,46 @@
         "@lezer/common": "^1.1.0"
       }
     },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-java": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.2.tgz",
+      "integrity": "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/java": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/lang-javascript": {
       "version": "6.2.4",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
@@ -1981,6 +2022,58 @@
         "@lezer/javascript": "^1.0.0"
       }
     },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.4.0.tgz",
+      "integrity": "sha512-ZeArR54seh4laFbUTVy0ZmQgO+C/cxxlW4jEoQMhL3HALScBpZBeZcLzrQmJsTEx4is9GzOe0bFAke2B1KZqeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-php": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
+      "integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/php": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz",
+      "integrity": "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/language": {
       "version": "6.11.3",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
@@ -1993,6 +2086,15 @@
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.2.tgz",
+      "integrity": "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
       }
     },
     "node_modules/@codemirror/lint": {
@@ -3481,6 +3583,17 @@
       "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
       "license": "MIT"
     },
+    "node_modules/@lezer/css": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.0.tgz",
+      "integrity": "sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
     "node_modules/@lezer/highlight": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
@@ -3488,6 +3601,28 @@
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.12.tgz",
+      "integrity": "sha512-RJ7eRWdaJe3bsiiLLHjCFT1JMk8m1YP9kaUbvu2rMLEoOnke9mcTVDyfOslsln0LtujdWespjJ39w6zo+RsQYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/java": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.1.3.tgz",
+      "integrity": "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/javascript": {
@@ -3501,6 +3636,17 @@
         "@lezer/lr": "^1.3.0"
       }
     },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@lezer/lr": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
@@ -3508,6 +3654,27 @@
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.4.3.tgz",
+      "integrity": "sha512-kfw+2uMrQ/wy/+ONfrH83OkdFNM0ye5Xq96cLlaCy7h5UT9FO54DU4oRoIc0CSBh5NWmWuiIJA7NGLMJbQ+Oxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/php": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.5.tgz",
+      "integrity": "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.1.0"
       }
     },
     "node_modules/@marijn/find-cluster-break": {
@@ -4442,6 +4609,44 @@
         "node": ">=20"
       }
     },
+    "node_modules/@sanity/code-input": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sanity/code-input/-/code-input-6.0.1.tgz",
+      "integrity": "sha512-4XANd/rpCw3rdXkx22zdpVdzN0Xtj4Cc5b6hklRWVdIvt5zDy8z3WS9G8f9SXWNU05Zs0bP7sAPEoWvj5bk7fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.18.3",
+        "@codemirror/commands": "^6.7.1",
+        "@codemirror/lang-html": "^6.4.9",
+        "@codemirror/lang-java": "^6.0.1",
+        "@codemirror/lang-javascript": "^6.2.2",
+        "@codemirror/lang-json": "^6.0.1",
+        "@codemirror/lang-markdown": "^6.3.1",
+        "@codemirror/lang-php": "^6.0.1",
+        "@codemirror/lang-sql": "^6.8.0",
+        "@codemirror/language": "^6.10.6",
+        "@codemirror/legacy-modes": "^6.4.2",
+        "@codemirror/search": "^6.5.8",
+        "@codemirror/state": "^6.5.0",
+        "@codemirror/view": "^6.35.3",
+        "@juggle/resize-observer": "^3.4.0",
+        "@lezer/highlight": "^1.2.1",
+        "@sanity/icons": "^3.5.2",
+        "@sanity/incompatible-plugin": "^1.0.4",
+        "@sanity/ui": "^3.0.5",
+        "@uiw/codemirror-themes": "^4.23.6",
+        "@uiw/react-codemirror": "^4.23.6"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "react": "^18 || >=19.0.0-0",
+        "react-dom": "^18 || >=19.0.0-0",
+        "sanity": "^3 || ^4.0.0-0",
+        "styled-components": "^5.2 || ^6"
+      }
+    },
     "node_modules/@sanity/codegen": {
       "version": "4.10.2",
       "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-4.10.2.tgz",
@@ -4907,6 +5112,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sanity/incompatible-plugin": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@sanity/incompatible-plugin/-/incompatible-plugin-1.0.5.tgz",
+      "integrity": "sha512-9JGAacbElUPy9Chghd+sllIiM3jAcraZdD65bWYWUVKkghOsf1L/+jFLz1rcAuvrA9o2s7Y+T75BNcXuLwRcvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.9 || ^17 || ^18 || ^19",
+        "react-dom": "^16.9 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@sanity/insert-menu": {
@@ -6319,6 +6534,25 @@
         "@codemirror/language": ">=6.0.0",
         "@codemirror/lint": ">=6.0.0",
         "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/codemirror-themes": {
+      "version": "4.25.2",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.25.2.tgz",
+      "integrity": "sha512-WFYxW3OlCkMomXQBlQdGj1JZ011UNCa7xYdmgYqywVc4E8f5VgIzRwCZSBNVjpWGGDBOjc+Z6F65l7gttP16pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/language": ">=6.0.0",
         "@codemirror/state": ">=6.0.0",
         "@codemirror/view": ">=6.0.0"
       }

--- a/playbook-mint/sanity/package.json
+++ b/playbook-mint/sanity/package.json
@@ -15,6 +15,7 @@
     "sanity"
   ],
   "dependencies": {
+    "@sanity/code-input": "^6.0.1",
     "@sanity/vision": "^4.10.2",
     "react": "^19.1",
     "react-dom": "^19.1",

--- a/playbook-mint/sanity/sanity.config.ts
+++ b/playbook-mint/sanity/sanity.config.ts
@@ -1,6 +1,7 @@
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
+import {codeInput} from '@sanity/code-input'
 import {schemaTypes} from './schemaTypes'
 
 export default defineConfig({
@@ -10,7 +11,7 @@ export default defineConfig({
   projectId: 'qdgro20q',
   dataset: 'production',
 
-  plugins: [structureTool(), visionTool()],
+  plugins: [structureTool(), visionTool(), codeInput()],
 
   schema: {
     types: schemaTypes,

--- a/playbook-mint/src/app/api/revalidate/route.ts
+++ b/playbook-mint/src/app/api/revalidate/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest } from "next/server";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { isValidSignature, SIGNATURE_HEADER_NAME } from "@sanity/webhook";
+
+type SanitySlug = {
+  current?: string | null;
+};
+
+interface SanityWebhookPayload {
+  _type?: string;
+  slug?: SanitySlug;
+  draft?: { slug?: SanitySlug } | null;
+  previous?: { slug?: SanitySlug } | null;
+  transition?: "create" | "update" | "delete";
+}
+
+const ARTICLE_TYPE = "article";
+
+function extractSlug(payload: SanityWebhookPayload): string | null {
+  const slugCandidate =
+    payload.slug?.current ||
+    payload.draft?.slug?.current ||
+    payload.previous?.slug?.current ||
+    null;
+
+  return typeof slugCandidate === "string" && slugCandidate.length > 0
+    ? slugCandidate
+    : null;
+}
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  const secret = process.env.SANITY_REVALIDATE_SECRET;
+
+  if (!secret) {
+    return Response.json(
+      {
+        error: "Missing SANITY_REVALIDATE_SECRET environment variable",
+      },
+      { status: 500 },
+    );
+  }
+
+  const signature = request.headers.get(SIGNATURE_HEADER_NAME) ?? "";
+  const body = await request.text();
+
+  if (!isValidSignature(body, signature, secret)) {
+    return Response.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  let payload: SanityWebhookPayload;
+
+  try {
+    payload = JSON.parse(body) as SanityWebhookPayload;
+  } catch (error) {
+    return Response.json(
+      { error: "Unable to parse webhook payload", details: String(error) },
+      { status: 400 },
+    );
+  }
+
+  if (payload._type !== ARTICLE_TYPE) {
+    return Response.json({ skipped: true, reason: "Unsupported document type" });
+  }
+
+  const slug = extractSlug(payload);
+
+  revalidateTag("article-detail");
+  revalidateTag("article-list");
+  revalidateTag("article-slugs");
+
+  const revalidatedPaths: string[] = [];
+
+  if (slug) {
+    const articlePath = `/articles/${slug}`;
+    revalidatePath(articlePath);
+    revalidatedPaths.push(articlePath);
+  }
+
+  revalidatePath("/articles");
+  revalidatedPaths.push("/articles");
+
+  return Response.json({
+    revalidated: true,
+    slug,
+    transition: payload.transition,
+    paths: revalidatedPaths,
+  });
+}

--- a/playbook-mint/src/lib/articles.ts
+++ b/playbook-mint/src/lib/articles.ts
@@ -1,4 +1,4 @@
-import { cache } from "react";
+import { unstable_cache } from "next/cache";
 import readingTime from "reading-time";
 import { z } from "zod";
 import type { PortableTextBlock } from "@portabletext/types";
@@ -80,7 +80,7 @@ function mapArticle(record: ArticleRecord): ArticleFrontmatter {
   } satisfies ArticleFrontmatter;
 }
 
-export const getArticleBySlug = cache(async (slug: string): Promise<ArticleDetail> => {
+const fetchArticleDetail = async (slug: string): Promise<ArticleDetail> => {
   const result = await readClient.fetch(ARTICLE_QUERY, { slug });
   const parsed = articleDetailSchema.parse(result);
   const frontmatter = mapArticle(parsed);
@@ -89,23 +89,55 @@ export const getArticleBySlug = cache(async (slug: string): Promise<ArticleDetai
     ...frontmatter,
     body: parsed.body,
   } satisfies ArticleDetail;
-});
+};
 
-export const getArticleFrontmatter = cache(async (slug: string): Promise<ArticleFrontmatter> => {
-  const result = await readClient.fetch(ARTICLE_QUERY, { slug });
-  const parsed = articleDetailSchema.parse(result);
-  return mapArticle(parsed);
-});
-
-export const listArticles = cache(async (): Promise<ArticleFrontmatter[]> => {
+const fetchArticleList = async (): Promise<ArticleFrontmatter[]> => {
   const result = await readClient.fetch(ARTICLE_LIST_QUERY);
   const parsed = z.array(baseArticleSchema).parse(result ?? []);
   const articles = parsed.map(mapArticle);
   return articles.sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
-});
+};
 
-export const listArticleSlugs = cache(async (): Promise<string[]> => {
+const fetchArticleSlugs = async (): Promise<string[]> => {
   const result = await readClient.fetch(ARTICLE_SLUGS_QUERY);
   const parsed = z.array(z.string()).parse(result ?? []);
   return parsed;
+};
+
+export const getArticleBySlug = unstable_cache(fetchArticleDetail, [
+  "articles",
+  "detail",
+], {
+  tags: ["article-detail"],
+});
+
+export async function getArticleFrontmatter(slug: string): Promise<ArticleFrontmatter> {
+  const article = await getArticleBySlug(slug);
+
+  return {
+    title: article.title,
+    description: article.description,
+    slug: article.slug,
+    publishedAt: article.publishedAt,
+    updatedAt: article.updatedAt,
+    tags: article.tags,
+    heroImage: article.heroImage,
+    heroImageAlt: article.heroImageAlt ?? null,
+    playbookSku: article.playbookSku,
+    readingMinutes: article.readingMinutes,
+  } satisfies ArticleFrontmatter;
+}
+
+export const listArticles = unstable_cache(fetchArticleList, [
+  "articles",
+  "list",
+], {
+  tags: ["article-list"],
+});
+
+export const listArticleSlugs = unstable_cache(fetchArticleSlugs, [
+  "articles",
+  "slugs",
+], {
+  tags: ["article-slugs"],
 });

--- a/sanity-implementation-review.md
+++ b/sanity-implementation-review.md
@@ -1,0 +1,40 @@
+# Sanity Integration Review
+
+## Current Implementation Snapshot
+
+### Studio configuration (`playbook-mint/sanity`)
+- Sanity Studio lives in `playbook-mint/sanity` with a single project configuration that targets the `qdgro20q` project and `production` dataset, and loads the default desk structure plus Vision for GROQ debugging.【F:playbook-mint/sanity/sanity.config.ts†L1-L18】
+- The article document schema models all front matter fields we previously relied on in MDX: title, slug, SEO-friendly description, publish/update timestamps, tag arrays (capped at six), hero image with required alt text, optional listing alt override, a featured playbook SKU, and a rich `body` array that accepts block content, inline link annotations, images, code blocks, and a custom CTA object.【F:playbook-mint/sanity/schemaTypes/documents/article.ts†L3-L131】
+- A dedicated `ctaPlaybook` object type backs the article body CTA block so authors can embed SKU-specific upsells without manual JSX edits.【F:playbook-mint/sanity/schemaTypes/objects/ctaPlaybook.ts†L3-L24】
+
+### Application-side integration (`playbook-mint/src`)
+- Runtime configuration pulls `SANITY_PROJECT_ID`, `SANITY_DATASET`, and `SANITY_API_VERSION` from environment variables at module load; missing IDs throw eagerly to prevent silent misconfiguration.【F:playbook-mint/src/lib/sanity/config.ts†L1-L18】
+- `createClient` from `next-sanity` instantiates a CDN-enabled read client (with optional steganography overlays in non-production environments) and exposes a token-aware preview client, although no preview entry points consume it yet.【F:playbook-mint/src/lib/sanity/client.ts†L1-L34】
+- Centralized GROQ queries provide article detail, listing, and slug lookups—including derived plain-text bodies for reading-time calculations—giving the Next.js app a single source of truth for Sanity reads.【F:playbook-mint/src/lib/sanity/queries.ts†L1-L36】
+- `src/lib/articles.ts` wraps the Sanity client with Zod validation, runtime type coercion for Portable Text and images, and helpers for fetching individual articles, front matter summaries, collections, and static params; it also computes reading length from Portable Text output to preserve the existing UX badge.【F:playbook-mint/src/lib/articles.ts†L1-L111】
+- Portable Text rendering mirrors our MDX typography by mapping blocks, marks, lists, CTA objects, and responsive Sanity images to the design system, ensuring Sanity-authored content slots into existing layouts.【F:playbook-mint/src/components/sanity/portable-text.tsx†L1-L104】
+- Article routes (`/articles` and `/articles/[slug]`) already depend entirely on the Sanity-backed helpers for listing and rendering content, providing sensible empty states when the dataset has no published entries.【F:playbook-mint/src/app/(site)/articles/page.tsx†L1-L35】【F:playbook-mint/src/app/(site)/articles/[slug]/page.tsx†L1-L91】
+
+### Legacy surface area still in place
+- The MDX content directory (`playbook-mint/content/articles`) remains checked in, signalling that the migration is mid-flight and dual maintenance is still required until content is imported into Sanity.【F:playbook-mint/content/articles/beginner-budgeting-guide.mdx†L1-L40】
+
+## Strengths observed
+- **Parity-focused schema** – The article document captures all metadata we needed from MDX, with validation rules that enforce quality standards such as SEO-length descriptions and mandatory image alt text.【F:playbook-mint/sanity/schemaTypes/documents/article.ts†L7-L114】
+- **Type-safe data access** – Zod schemas guard our Sanity responses, reducing the risk of runtime regressions as editors start creating content.【F:playbook-mint/src/lib/articles.ts†L9-L111】
+- **Design-consistent rendering** – Custom Portable Text components replicate our MDX presentation layer, including CTA blocks, so we do not lose marketing hooks when switching backends.【F:playbook-mint/src/components/sanity/portable-text.tsx†L13-L104】
+
+## Gaps & technical risks
+- **Preview and drafts unimplemented** – Although a preview client helper exists, there is no draft-mode API route or middleware to surface unpublished changes, limiting editorial feedback loops.【F:playbook-mint/src/lib/sanity/client.ts†L20-L34】
+- **Revalidation strategy TBD** – Static routes call `cache` wrappers but do not declare `revalidate` intervals nor webhooks, so fresh publishes will not automatically appear in production without manual cache busting.【F:playbook-mint/src/lib/articles.ts†L83-L111】
+- **Environment management split** – The Studio hard-codes the project ID/dataset while the Next.js app expects env vars. Without documentation, it is easy for developers to configure one side and forget the other, or accidentally point Studio previews at the wrong dataset.【F:playbook-mint/sanity/sanity.config.ts†L6-L18】【F:playbook-mint/src/lib/sanity/config.ts†L1-L18】
+- **Content migration incomplete** – Legacy MDX files are still the source of truth; until they are imported (or an automated bridge exists) the Sanity-backed frontend will surface empty states in lower environments.【F:playbook-mint/content/articles/beginner-budgeting-guide.mdx†L1-L40】【F:playbook-mint/src/app/(site)/articles/page.tsx†L23-L31】
+- **Hero media unused on frontend** – Article listings/pages do not yet render the new `heroImage` field, reducing parity with the MDX experience and making it harder to validate image handling end-to-end.【F:playbook-mint/src/lib/articles.ts†L69-L80】【F:playbook-mint/src/app/(site)/articles/[slug]/page.tsx†L62-L88】
+- **Playbook SKU freeform** – The CTA object enforces a SKU string but does not validate against existing playbooks or provide authoring affordances (references, dropdowns), inviting typos until additional schema is added.【F:playbook-mint/sanity/schemaTypes/objects/ctaPlaybook.ts†L7-L24】
+
+## Recommended next steps
+1. **Finish content migration** – Import existing MDX articles into Sanity (or build a bridge script) so the live site is populated during rollout; remove the filesystem content once parity is verified.【F:playbook-mint/content/articles/beginner-budgeting-guide.mdx†L1-L40】【F:playbook-mint/src/lib/articles.ts†L83-L111】
+2. **Wire up preview & drafts** – Add a preview secret route, enable `draftMode`, and plumb the `getPreviewClient` into article pages so editors can QA unpublished changes safely.【F:playbook-mint/src/lib/sanity/client.ts†L20-L34】【F:playbook-mint/src/app/(site)/articles/[slug]/page.tsx†L51-L91】
+3. **Define revalidation + webhooks** – Decide on ISR timing or on-demand revalidation and configure Sanity webhooks to trigger Next.js cache busting after publishes.【F:playbook-mint/src/lib/articles.ts†L83-L111】
+4. **Document environment setup** – Create a shared doc (and `.env.example` entries) that lists required Sanity variables for both Studio and Next.js, and consider aligning Studio config to read from env to avoid drift.【F:playbook-mint/sanity/sanity.config.ts†L6-L18】【F:playbook-mint/src/lib/sanity/config.ts†L1-L18】
+5. **Surface hero media and CTAs** – Update article and listing templates to render `heroImage` blocks and validate CTA SKU inputs (e.g., via references to a playbook document) to complete parity with the MDX presentation.【F:playbook-mint/src/lib/articles.ts†L69-L80】【F:playbook-mint/src/components/sanity/portable-text.tsx†L63-L104】
+6. **Plan cleanup and dependency removal** – Once content lives in Sanity, remove unused MDX tooling/dependencies to reduce bundle size and maintenance overhead (e.g., delete `playbook-mint/content`, drop MDX packages).【F:playbook-mint/content/articles/beginner-budgeting-guide.mdx†L1-L40】【F:playbook-mint/src/lib/articles.ts†L1-L111】


### PR DESCRIPTION
## Summary
- install the Sanity code input plugin so the `code` block type resolves during schema compilation
- register the plugin in the studio configuration to unblock running the Sanity dev server

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6ed4661c833091d4f0de31b011f5